### PR TITLE
Add category management pages and security fix

### DIFF
--- a/src/main/java/com/univille/controle_financeiro/controller/WebController.java
+++ b/src/main/java/com/univille/controle_financeiro/controller/WebController.java
@@ -25,4 +25,9 @@ public class WebController {
     public String dashboard() {
         return "dashboard";
     }
+
+    @GetMapping("/categories")
+    public String categories() {
+        return "categories";
+    }
 }

--- a/src/main/java/com/univille/controle_financeiro/security/SecurityConfig.java
+++ b/src/main/java/com/univille/controle_financeiro/security/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
                 .and()
                 .authorizeHttpRequests(authz -> authz
                         // agora só precisamos liberar explicitamente as páginas públicas
-                        .requestMatchers("/", "/login", "/register", "/api/auth/**", "/h2-console/**")
+                        .requestMatchers("/", "/login", "/register", "/dashboard", "/categories", "/api/auth/**", "/h2-console/**")
                         .permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/static/css/categories.css
+++ b/src/main/resources/static/css/categories.css
@@ -1,0 +1,37 @@
+.categories-content {
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    width: 100%;
+    max-width: 600px;
+}
+
+.categories-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+.categories-table th,
+.categories-table td {
+    padding: 10px;
+    border-bottom: 1px solid #ddd;
+    text-align: left;
+}
+
+.categories-table td.actions {
+    text-align: right;
+}
+
+.action-btn {
+    cursor: pointer;
+    background: none;
+    border: none;
+    color: #ff6b35;
+    margin-left: 5px;
+}
+
+.action-btn:hover {
+    text-decoration: underline;
+}

--- a/src/main/resources/static/js/categories.js
+++ b/src/main/resources/static/js/categories.js
@@ -1,0 +1,98 @@
+let categories = [];
+let editingId = null;
+
+document.addEventListener('DOMContentLoaded', function() {
+    if (!FinanceUtils.isLoggedIn()) {
+        window.location.href = '/login';
+        return;
+    }
+    const user = FinanceUtils.getCurrentUser();
+    const userName = document.getElementById('userName');
+    if (userName) userName.textContent = user.name;
+
+    loadCategories();
+    setupForm();
+});
+
+function setupForm() {
+    const form = document.getElementById('categoryForm');
+    const cancelBtn = document.getElementById('cancelEdit');
+
+    if (form) {
+        form.addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const name = document.getElementById('categoryName').value;
+            const payload = { name };
+            let url = '/api/categories';
+            let method = 'POST';
+            if (editingId) {
+                url += '/' + editingId;
+                method = 'PUT';
+            }
+            const resp = await FinanceUtils.fetchWithAuth(url, {
+                method,
+                body: JSON.stringify(payload)
+            });
+            if (resp && resp.ok) {
+                form.reset();
+                editingId = null;
+                if (cancelBtn) cancelBtn.style.display = 'none';
+                loadCategories();
+            } else if (resp) {
+                alert(await resp.text());
+            }
+        });
+    }
+
+    if (cancelBtn) {
+        cancelBtn.addEventListener('click', () => {
+            form.reset();
+            editingId = null;
+            cancelBtn.style.display = 'none';
+        });
+    }
+}
+
+async function loadCategories() {
+    const resp = await FinanceUtils.fetchWithAuth('/api/categories');
+    if (resp && resp.ok) {
+        categories = await resp.json();
+        renderTable();
+    }
+}
+
+function renderTable() {
+    const tbody = document.getElementById('categoriesTbody');
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    categories.forEach(cat => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${cat.name}</td>
+                        <td class="actions">
+                            <button class="action-btn" onclick="editCategory(${cat.id})">Editar</button>
+                            <button class="action-btn" onclick="deleteCategory(${cat.id})">Excluir</button>
+                        </td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+function editCategory(id) {
+    const cat = categories.find(c => c.id === id);
+    if (!cat) return;
+    document.getElementById('categoryName').value = cat.name;
+    editingId = id;
+    const cancelBtn = document.getElementById('cancelEdit');
+    if (cancelBtn) cancelBtn.style.display = 'inline-block';
+}
+
+async function deleteCategory(id) {
+    if (!confirm('Deseja remover esta categoria?')) return;
+    const resp = await FinanceUtils.fetchWithAuth('/api/categories/' + id, {
+        method: 'DELETE'
+    });
+    if (resp && resp.ok) {
+        loadCategories();
+    } else if (resp) {
+        alert(await resp.text());
+    }
+}

--- a/src/main/resources/static/js/dashboard.js
+++ b/src/main/resources/static/js/dashboard.js
@@ -285,7 +285,7 @@ function showTransactions() {
 }
 
 function showCategories() {
-    alert('Funcionalidade em desenvolvimento');
+    window.location.href = '/categories';
 }
 
 function showReports() {

--- a/src/main/resources/templates/categories.html
+++ b/src/main/resources/templates/categories.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Controle Financeiro - Categorias</title>
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/categories.css">
+</head>
+<body>
+<div class="overlay" id="overlay"></div>
+<div class="loading" id="loading">
+    <p>Carregando...</p>
+</div>
+
+<div class="header">
+    <div class="menu-icon">☰</div>
+    <div class="user-info">
+        <span class="user-name" id="userName"></span>
+        <button class="logout-btn" onclick="FinanceUtils.logout()">Sair</button>
+    </div>
+</div>
+
+<div class="container categories">
+    <div class="categories-content">
+        <h2>Gerenciar Categorias</h2>
+        <form id="categoryForm">
+            <input type="hidden" id="categoryId">
+            <div class="form-group">
+                <label for="categoryName">Nome</label>
+                <input type="text" id="categoryName" required>
+            </div>
+            <div class="form-group">
+                <button type="submit" class="btn btn-primary">Salvar</button>
+                <button type="button" id="cancelEdit" class="btn btn-secondary" style="display:none;">Cancelar</button>
+            </div>
+        </form>
+
+        <table class="categories-table">
+            <thead>
+            <tr><th>Nome</th><th style="width:120px;">Ações</th></tr>
+            </thead>
+            <tbody id="categoriesTbody"></tbody>
+        </table>
+    </div>
+</div>
+
+<script src="/js/common.js"></script>
+<script src="/js/categories.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add route and template for categories
- expose `/categories` and `/dashboard` as public routes
- add front-end page with CRUD of categories
- link categories from dashboard sidebar

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861afc27980832583a4a4c97e533f30